### PR TITLE
Fix Netlify configuration for proper Next.js deployment

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,16 +1,13 @@
 [build]
-  publish = "out"
-  command = "npm run build && npm run export"
+  publish = ".next"
+  command = "npm run build"
 
 [build.environment]
   NODE_VERSION = "18"
-  NPM_FLAGS = "--version"
+  NEXT_TELEMETRY_DISABLED = "1"
 
-# Redirect rules for SPA
-[[redirects]]
-  from = "/*"
-  to = "/index.html"
-  status = 200
+[[plugins]]
+  package = "@netlify/plugin-nextjs"
 
 # Security headers
 [[headers]]


### PR DESCRIPTION
## Summary
- Clean fix for Netlify deployment configuration
- Addresses fundamental issues in current netlify.toml
- Replaces the approach in PR #22 with a simpler, more direct solution

## Changes Made
- **✅ Publish directory**: Changed from `"out"` to `.next` (correct for Next.js)
- **✅ Build command**: Simplified to `npm run build` (removed non-existent export script)
- **✅ Added Next.js plugin**: `@netlify/plugin-nextjs` for automatic optimization
- **✅ Removed SPA redirect**: Plugin handles routing properly for Next.js
- **✅ Clean environment**: Added `NEXT_TELEMETRY_DISABLED` for cleaner builds

## Why This Works
1. **Correct publish directory**: Next.js builds to `.next`, not `out`
2. **Valid build command**: Uses existing npm script instead of non-existent one
3. **Netlify Next.js plugin**: Handles all Next.js-specific optimizations automatically
4. **No conflicting redirects**: Plugin manages routing without manual SPA rules

## Test Plan
- [x] ✅ Local build works (`npm run build`)
- [x] ✅ Configuration follows Netlify Next.js best practices
- [x] ✅ Removed all problematic elements from previous config

This replaces PR #22 with a cleaner, more direct approach.

🤖 Generated with [Claude Code](https://claude.ai/code)